### PR TITLE
More options for scrolling behavior

### DIFF
--- a/src/main/java/yalter/mousetweaks/Config.java
+++ b/src/main/java/yalter/mousetweaks/Config.java
@@ -17,6 +17,7 @@ public class Config {
 	public WheelScrollDirection wheelScrollDirection = WheelScrollDirection.NORMAL;
 	public Set<OnTickMethod> onTickMethodOrder = new LinkedHashSet<OnTickMethod>(); // The order has to be preserved.
 	public ScrollHandling scrollHandling = ScrollHandling.SIMPLE;
+	public ScrollItemScaling scrollItemScaling = ScrollItemScaling.PROPORTIONAL;
 	public static boolean debug = false;
 
 	public Config(String fileName) {
@@ -51,6 +52,7 @@ public class Config {
 		onTickMethodOrderFromString(properties.getProperty(Constants.CONFIG_ONTICK_METHOD_ORDER));
 		scrollHandling = ScrollHandling.fromId(parseIntOrDefault(properties.getProperty(Constants.CONFIG_SCROLL_HANDLING),
 		                                                         0));
+		scrollItemScaling = ScrollItemScaling.fromId(parseIntOrDefault(properties.getProperty(Constants.CONFIG_SCROLL_ITEM_SCALING), 0));
 		debug = parseIntOrDefault(properties.getProperty(Constants.CONFIG_DEBUG), 0) != 0;
 	}
 
@@ -82,6 +84,7 @@ public class Config {
 			            String.valueOf(wheelScrollDirection.ordinal()));
 			writeString(configWriter, Constants.CONFIG_ONTICK_METHOD_ORDER, onTickMethodOrderString());
 			writeString(configWriter, Constants.CONFIG_SCROLL_HANDLING, String.valueOf(scrollHandling.ordinal()));
+			writeString(configWriter, Constants.CONFIG_SCROLL_ITEM_SCALING, String.valueOf(scrollItemScaling.ordinal()));
 			writeBoolean(configWriter, Constants.CONFIG_DEBUG, debug);
 
 			configWriter.close();
@@ -145,6 +148,7 @@ public class Config {
 		defaultValues.setProperty(Constants.CONFIG_WHEEL_SCROLL_DIRECTION, "0");
 		defaultValues.setProperty(Constants.CONFIG_ONTICK_METHOD_ORDER, "Forge, LiteLoader");
 		defaultValues.setProperty(Constants.CONFIG_SCROLL_HANDLING, "0");
+		defaultValues.setProperty(Constants.CONFIG_SCROLL_ITEM_SCALING, "0");
 		defaultValues.setProperty(Constants.CONFIG_DEBUG, "0");
 	}
 }

--- a/src/main/java/yalter/mousetweaks/Constants.java
+++ b/src/main/java/yalter/mousetweaks/Constants.java
@@ -33,13 +33,6 @@ public class Constants {
 	static final String ONTICKMETHOD_FORGE_NAME = "Forge";
 	static final String ONTICKMETHOD_LITELOADER_NAME = "LiteLoader";
 
-	public static final String WHELL_SCROLL_DIRECTION_DESCRIPTION_NORMAL = "Down to push, up to pull";
-	public static final String WHELL_SCROLL_DIRECTION_DESCRIPTION_INVERTED = "Up to push, down to pull";
-	public static final String WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE = "Inventory position aware";
-	public static final String WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE_INVERTED = "Inventory position aware, inverted";
-
-	static final int INVENTORY_SIZE = 36; // Size of the player inventory
-
 	public enum EntryPoint {
 		UNDEFINED, FORGE, LITELOADER
 	}

--- a/src/main/java/yalter/mousetweaks/Constants.java
+++ b/src/main/java/yalter/mousetweaks/Constants.java
@@ -15,6 +15,7 @@ public class Constants {
 	static final String CONFIG_ONTICK_METHOD_ORDER = "OnTickMethodOrder";
 	static final String CONFIG_SCROLL_HANDLING = "ScrollHandling";
 	static final String CONFIG_DEBUG = "Debug";
+	static final String CONFIG_SCROLL_ITEM_SCALING = "ScrollItemScaling";
 
 	// Names for reflection.
 	public static final ObfuscatedName IGNOREMOUSEUP_NAME = new ObfuscatedName("ignoreMouseUp", "field_146995_H", "I");

--- a/src/main/java/yalter/mousetweaks/Constants.java
+++ b/src/main/java/yalter/mousetweaks/Constants.java
@@ -36,6 +36,7 @@ public class Constants {
 	public static final String WHELL_SCROLL_DIRECTION_DESCRIPTION_NORMAL = "Down to push, up to pull";
 	public static final String WHELL_SCROLL_DIRECTION_DESCRIPTION_INVERTED = "Up to push, down to pull";
 	public static final String WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE = "Inventory position aware";
+	public static final String WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE_INVERTED = "Inventory position aware, inverted";
 
 	static final int INVENTORY_SIZE = 36; // Size of the player inventory
 

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -290,7 +290,8 @@ public class Main {
 	}
 
 	private static void handleWheel(Slot selectedSlot) {
-		if (!config.wheelTweak || disableWheelForThisContainer) return;
+		if (!config.wheelTweak || disableWheelForThisContainer)
+			return;
 		int wheel = mouseState.consumeScrollAmount();
 
 		int numItemsToMove = Math.abs(wheel);

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -290,14 +290,10 @@ public class Main {
 	}
 
 	private static void handleWheel(Slot selectedSlot) {
-		int wheel = (config.wheelTweak && !disableWheelForThisContainer) ? mouseState.consumeScrollAmount() : 0;
+		if (!config.wheelTweak || disableWheelForThisContainer) return;
+		int wheel = mouseState.consumeScrollAmount();
 
-		int numItemsToMove;
-		if (config.scrollItemScaling == ScrollItemScaling.PROPORTIONAL) {
-			numItemsToMove = Math.abs(wheel) / 120;
-		} else {
-			numItemsToMove = wheel != 0 ? 1 : 0;
-		}
+		int numItemsToMove = Math.abs(wheel);
 		
 		if (numItemsToMove == 0 || selectedSlot == null || handler.isIgnored(selectedSlot))
 			return;

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -290,9 +290,15 @@ public class Main {
 	}
 
 	private static void handleWheel(Slot selectedSlot) {
-		int wheel = (config.wheelTweak && !disableWheelForThisContainer) ? mouseState.consumeScrollAmount() / 120 : 0;
+		int wheel = (config.wheelTweak && !disableWheelForThisContainer) ? mouseState.consumeScrollAmount() : 0;
 
-		int numItemsToMove = Math.abs(wheel);
+		int numItemsToMove;
+		if (config.scrollItemScaling == ScrollItemScaling.PROPORTIONAL) {
+			numItemsToMove = Math.abs(wheel) / 120;
+		} else {
+			numItemsToMove = wheel != 0 ? 1 : 0;
+		}
+		
 		if (numItemsToMove == 0 || selectedSlot == null || handler.isIgnored(selectedSlot))
 			return;
 

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -316,13 +316,14 @@ public class Main {
 
 		List<Slot> slots = handler.getSlots();
 
-		if (config.wheelScrollDirection == WheelScrollDirection.INVERTED || (config.wheelScrollDirection
-		                                                                     == WheelScrollDirection.INVENTORY_POSITION_AWARE
-		                                                                     && otherInventoryIsAbove(selectedSlot,
-		                                                                                              slots))) {
+		// this could be combined with !=, but it's more readable this way
+		if (config.wheelScrollDirection.isPositionAware() && otherInventoryIsAbove(selectedSlot, slots)) {
 			wheel = -wheel;
 		}
-		boolean pushItems = (wheel < 0);
+		if (config.wheelScrollDirection.isInverted()) {
+			wheel = -wheel;
+		}
+		boolean pushItems = wheel < 0;
 
 		if (isCraftingOutput) {
 			if (pushItems) {

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -313,13 +313,13 @@ public class Main {
 
 		List<Slot> slots = handler.getSlots();
 
+		boolean pushItems = wheel < 0;
 		if (config.wheelScrollDirection.isPositionAware() && otherInventoryIsAbove(selectedSlot, slots)) {
-			wheel = -wheel;
+			pushItems = !pushItems;
 		}
 		if (config.wheelScrollDirection.isInverted()) {
-			wheel = -wheel;
+			pushItems = !pushItems;
 		}
-		boolean pushItems = wheel < 0;
 
 		if (isCraftingOutput) {
 			if (pushItems) {

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -313,7 +313,6 @@ public class Main {
 
 		List<Slot> slots = handler.getSlots();
 
-		// this could be combined with !=, but it's more readable this way
 		if (config.wheelScrollDirection.isPositionAware() && otherInventoryIsAbove(selectedSlot, slots)) {
 			wheel = -wheel;
 		}

--- a/src/main/java/yalter/mousetweaks/ScrollItemScaling.java
+++ b/src/main/java/yalter/mousetweaks/ScrollItemScaling.java
@@ -1,0 +1,23 @@
+package yalter.mousetweaks;
+
+public enum ScrollItemScaling {
+	PROPORTIONAL(0), ALWAYS_ONE(1);
+
+	private final int id;
+
+	ScrollItemScaling(int id) {
+		this.id = id;
+	}
+
+	public int getValue() {
+		return id;
+	}
+
+	public static ScrollItemScaling fromId(int id) {
+		if (id == PROPORTIONAL.id) {
+			return PROPORTIONAL;
+		} else {
+			return ALWAYS_ONE;
+		}
+	}
+}

--- a/src/main/java/yalter/mousetweaks/ScrollItemScaling.java
+++ b/src/main/java/yalter/mousetweaks/ScrollItemScaling.java
@@ -24,12 +24,12 @@ public enum ScrollItemScaling {
 	/**
 	 * scales the given scroll distance, resulting in the number of items to move, the sign representing the direction
 	 */
-	public int scale(int scrollDelta) {
+	public double scale(double scrollDelta) {
 		switch (this) {
 			case PROPORTIONAL:
 				return scrollDelta / 120;
 			case ALWAYS_ONE:
-				return Integer.signum(scrollDelta);
+				return Math.signum(scrollDelta);
 			default:
 				throw new AssertionError();
 		}

--- a/src/main/java/yalter/mousetweaks/ScrollItemScaling.java
+++ b/src/main/java/yalter/mousetweaks/ScrollItemScaling.java
@@ -20,4 +20,18 @@ public enum ScrollItemScaling {
 			return ALWAYS_ONE;
 		}
 	}
+
+	/**
+	 * scales the given scroll distance, resulting in the number of items to move, the sign representing the direction
+	 */
+	public int scale(int scrollDelta) {
+		switch (this) {
+			case PROPORTIONAL:
+				return scrollDelta / 120;
+			case ALWAYS_ONE:
+				return Integer.signum(scrollDelta);
+			default:
+				throw new AssertionError();
+		}
+	}
 }

--- a/src/main/java/yalter/mousetweaks/ScrollItemScaling.java
+++ b/src/main/java/yalter/mousetweaks/ScrollItemScaling.java
@@ -3,6 +3,8 @@ package yalter.mousetweaks;
 public enum ScrollItemScaling {
 	PROPORTIONAL(0), ALWAYS_ONE(1);
 
+	public static final int scrollStep = 120;
+
 	private final int id;
 
 	ScrollItemScaling(int id) {
@@ -24,12 +26,12 @@ public enum ScrollItemScaling {
 	/**
 	 * scales the given scroll distance, resulting in the number of items to move, the sign representing the direction
 	 */
-	public double scale(double scrollDelta) {
+	public int scale(int scrollDelta) {
 		switch (this) {
 			case PROPORTIONAL:
-				return scrollDelta / 120;
+				return scrollDelta;
 			case ALWAYS_ONE:
-				return Math.signum(scrollDelta);
+				return Integer.signum(scrollDelta) * scrollStep;
 			default:
 				throw new AssertionError();
 		}

--- a/src/main/java/yalter/mousetweaks/SimpleMouseState.java
+++ b/src/main/java/yalter/mousetweaks/SimpleMouseState.java
@@ -3,7 +3,7 @@ package yalter.mousetweaks;
 import org.lwjgl.input.Mouse;
 
 /**
- * Simple stateless mouse state.
+ * Simple polling mouse state.
  * <p>
  * This has an advantage of offering smooth scrolling (if polled every render tick it will return scroll events
  * appropriately). Unfortunately, it doesn't always play well with other mods: clicks handled by other mods will also be
@@ -13,13 +13,24 @@ import org.lwjgl.input.Mouse;
  * - https://github.com/YaLTeR/MouseTweaks/issues/19
  */
 public class SimpleMouseState implements IMouseState {
+	private double scrollAmount = 0;
+
 	@Override
 	public boolean isButtonPressed(MouseButton mouseButton) {
 		return Mouse.isButtonDown(mouseButton.getValue());
 	}
 
 	@Override
+	public void clear() {
+		scrollAmount = 0;
+	}
+
+	@Override
 	public int consumeScrollAmount() {
-		return Main.config.scrollItemScaling.scale(Mouse.getDWheel());
+		scrollAmount += Main.config.scrollItemScaling.scale(Mouse.getDWheel());
+
+		int amountToConsume = (int) scrollAmount;
+		scrollAmount -= amountToConsume;
+		return amountToConsume;
 	}
 }

--- a/src/main/java/yalter/mousetweaks/SimpleMouseState.java
+++ b/src/main/java/yalter/mousetweaks/SimpleMouseState.java
@@ -20,6 +20,6 @@ public class SimpleMouseState implements IMouseState {
 
 	@Override
 	public int consumeScrollAmount() {
-		return Mouse.getDWheel();
+		return Main.config.scrollItemScaling.scale(Mouse.getDWheel());
 	}
 }

--- a/src/main/java/yalter/mousetweaks/SimpleMouseState.java
+++ b/src/main/java/yalter/mousetweaks/SimpleMouseState.java
@@ -13,7 +13,7 @@ import org.lwjgl.input.Mouse;
  * - https://github.com/YaLTeR/MouseTweaks/issues/19
  */
 public class SimpleMouseState implements IMouseState {
-	private double scrollAmount = 0;
+	private int scrollAmount = 0;
 
 	@Override
 	public boolean isButtonPressed(MouseButton mouseButton) {
@@ -29,8 +29,8 @@ public class SimpleMouseState implements IMouseState {
 	public int consumeScrollAmount() {
 		scrollAmount += Main.config.scrollItemScaling.scale(Mouse.getDWheel());
 
-		int amountToConsume = (int) scrollAmount;
-		scrollAmount -= amountToConsume;
-		return amountToConsume;
+		int amountConsumed = scrollAmount / ScrollItemScaling.scrollStep;
+		scrollAmount -= amountConsumed * ScrollItemScaling.scrollStep;
+		return amountConsumed;
 	}
 }

--- a/src/main/java/yalter/mousetweaks/WheelScrollDirection.java
+++ b/src/main/java/yalter/mousetweaks/WheelScrollDirection.java
@@ -1,7 +1,7 @@
 package yalter.mousetweaks;
 
 public enum WheelScrollDirection {
-	NORMAL(0), INVERTED(1), INVENTORY_POSITION_AWARE(2);
+	NORMAL(0), INVERTED(1), INVENTORY_POSITION_AWARE(2), INVENTORY_POSITION_AWARE_INVERTED(3);
 
 	private final int id;
 
@@ -16,10 +16,20 @@ public enum WheelScrollDirection {
 	public static WheelScrollDirection fromId(int id) {
 		if (id == NORMAL.id) {
 			return NORMAL;
+		} else if (id == INVERTED.id) {
+			return INVERTED;
 		} else if (id == INVENTORY_POSITION_AWARE.id) {
 			return INVENTORY_POSITION_AWARE;
 		} else {
-			return INVERTED;
+			return INVENTORY_POSITION_AWARE_INVERTED;
 		}
+	}
+	
+	public boolean isInverted() {
+		return this == INVERTED || this == INVENTORY_POSITION_AWARE_INVERTED;
+	}
+	
+	public boolean isPositionAware() {
+		return this == INVENTORY_POSITION_AWARE || this == INVENTORY_POSITION_AWARE_INVERTED;
 	}
 }

--- a/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
+++ b/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
@@ -35,6 +35,11 @@ public class ConfigGui extends GuiConfig {
 	                                                      Property.Type.STRING,
 	                                                      new String[]{ "Smooth scrolling, minor issues",
 	                                                                    "Non-smooth scrolling, no issues" });
+	private static Property scrollItemScaling = new Property("Scroll item scaling",
+															 "Relative to scroll amount",
+															 Property.Type.STRING,
+															 new String[]{ "Relative to scroll amount",
+																		   "Always exactly one item" });
 	private static Property debug = new Property("Debug", "false", Property.Type.BOOLEAN);
 
 	private boolean is_open = false;
@@ -57,6 +62,7 @@ public class ConfigGui extends GuiConfig {
 		scrollHandling.setComment(
 			"When set to smooth scrolling, minor issues may be experienced such as scrolling \"through\" "
 			+ "JEI or other mods. Non-smooth scrolling works only with the Forge OnTick method.");
+		scrollItemScaling.setComment("This determines how many items are moved when you scroll.");
 		debug.setComment("Enables debug logging output.");
 	}
 
@@ -71,6 +77,7 @@ public class ConfigGui extends GuiConfig {
 		list.add(new ConfigElement(wheelScrollDirection));
 		list.add(new ConfigElement(onTickMethodOrder));
 		list.add(new ConfigElement(scrollHandling));
+		list.add(new ConfigElement(scrollItemScaling));
 		list.add(new ConfigElement(debug));
 
 		return list;
@@ -94,6 +101,7 @@ public class ConfigGui extends GuiConfig {
 			wheelScrollDirection.set(scrollDirectionDescription());
 			onTickMethodOrder.set(Main.config.onTickMethodOrderString());
 			scrollHandling.set(scrollHandling.getValidValues()[Main.config.scrollHandling.ordinal()]);
+			scrollItemScaling.set(scrollItemScaling.getValidValues()[Main.config.scrollItemScaling.ordinal()]);
 			debug.set(Config.debug);
 		}
 
@@ -120,12 +128,14 @@ public class ConfigGui extends GuiConfig {
 		Main.config.lmbTweakWithoutItem = lmbTweakWithoutItem.getBoolean();
 		Main.config.wheelTweak = wheelTweak.getBoolean();
 		Main.config.wheelSearchOrder = wheelSearchOrder.getString().equals("First to last")
-		                               ? WheelSearchOrder.FIRST_TO_LAST
-		                               : WheelSearchOrder.LAST_TO_FIRST;
+									   ? WheelSearchOrder.FIRST_TO_LAST
+									   : WheelSearchOrder.LAST_TO_FIRST;
 		Main.config.wheelScrollDirection = scrollDirectionFromDescription(wheelScrollDirection.getString());
 		Main.config.onTickMethodOrderFromString(onTickMethodOrder.getString());
 		Main.config.scrollHandling = ScrollHandling.fromId(Arrays.asList(scrollHandling.getValidValues())
 		                                                         .indexOf(scrollHandling.getString()));
+		Main.config.scrollItemScaling = ScrollItemScaling.fromId(Arrays.asList(scrollItemScaling.getValidValues())
+			.indexOf(scrollItemScaling.getString()));
 		Config.debug = debug.getBoolean();
 		Main.config.save();
 		Main.findOnTickMethod(true);

--- a/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
+++ b/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
@@ -63,7 +63,7 @@ public class ConfigGui extends GuiConfig {
 		scrollHandling.setComment(
 			"When set to smooth scrolling, minor issues may be experienced such as scrolling \"through\" "
 			+ "JEI or other mods. Non-smooth scrolling works only with the Forge OnTick method.");
-		scrollItemScaling.setComment("This determines how many items are moved when you scroll.");
+		scrollItemScaling.setComment("This determines how many items are moved when you scroll. On some setups (notably macOS), scrolling the wheel with different speeds results in different distances scrolled per wheel \"bump\". To make those setups play nicely with Mouse Tweaks, set this option to \"Always exactly one item\".");
 		debug.setComment("Enables debug logging output.");
 	}
 

--- a/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
+++ b/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
@@ -38,21 +38,21 @@ public class ConfigGui extends GuiConfig {
 		"Always exactly one item"
 	);
 	private static Property debug = booleanProperty("Debug", false);
-	
+
 	private static Property booleanProperty(String name, boolean defaultValue) {
 		return new Property(name, Boolean.toString(defaultValue), Property.Type.BOOLEAN);
 	}
-	
+
 	/** creates a new string property with the given valid values, taking the first valid value as default */
 	private static Property choiceProperty(String name, String... values) {
 		return new Property(name, values[0], Property.Type.STRING, values);
 	}
-	
+
 	private boolean is_open = false;
-	
+
 	public ConfigGui(GuiScreen parentScreen) {
 		super(parentScreen, getConfigElements(), Constants.MOD_ID, false, false, ".minecraft/config/MouseTweaks.cfg");
-		
+
 		rmbTweak.setComment("Like vanilla right click dragging, but dragging over a slot multiple times puts the item there multiple times.");
 		lmbTweakWithItem.setComment("Left click and drag with an item to \"left click\" items of the same type.");
 		lmbTweakWithoutItem.setComment("Hold shift, left click and drag without an item to \"shift left click\" items.");
@@ -64,10 +64,10 @@ public class ConfigGui extends GuiConfig {
 		scrollItemScaling.setComment("This determines how many items are moved when you scroll. On some setups (notably macOS), scrolling the wheel with different speeds results in different distances scrolled per wheel \"bump\". To make those setups play nicely with Mouse Tweaks, set this option to \"Always exactly one item\".");
 		debug.setComment("Enables debug logging output.");
 	}
-	
+
 	private static List<IConfigElement> getConfigElements() {
 		List<IConfigElement> list = new ArrayList<IConfigElement>();
-		
+
 		list.add(new ConfigElement(rmbTweak));
 		list.add(new ConfigElement(lmbTweakWithItem));
 		list.add(new ConfigElement(lmbTweakWithoutItem));
@@ -78,17 +78,17 @@ public class ConfigGui extends GuiConfig {
 		list.add(new ConfigElement(scrollHandling));
 		list.add(new ConfigElement(scrollItemScaling));
 		list.add(new ConfigElement(debug));
-		
+
 		return list;
 	}
-	
+
 	@Override
 	public void initGui() {
 		Logger.DebugLog("initGui()");
-		
+
 		if (!is_open) {
 			is_open = true;
-			
+
 			Main.config.read();
 			rmbTweak.set(Main.config.rmbTweak);
 			lmbTweakWithItem.set(Main.config.lmbTweakWithItem);
@@ -103,14 +103,14 @@ public class ConfigGui extends GuiConfig {
 			scrollItemScaling.set(scrollItemScaling.getValidValues()[Main.config.scrollItemScaling.ordinal()]);
 			debug.set(Config.debug);
 		}
-		
+
 		super.initGui();
 	}
-	
+
 	@Override
 	public void onGuiClosed() {
 		Logger.DebugLog("onGuiClosed()");
-		
+
 		Main.config.rmbTweak = rmbTweak.getBoolean();
 		Main.config.lmbTweakWithItem = lmbTweakWithItem.getBoolean();
 		Main.config.lmbTweakWithoutItem = lmbTweakWithoutItem.getBoolean();
@@ -128,7 +128,7 @@ public class ConfigGui extends GuiConfig {
 		Config.debug = debug.getBoolean();
 		Main.config.save();
 		Main.findOnTickMethod(true);
-		
+
 		is_open = false;
 		super.onGuiClosed();
 	}

--- a/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
+++ b/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
@@ -7,69 +7,74 @@ import net.minecraftforge.fml.client.config.GuiConfig;
 import net.minecraftforge.fml.client.config.IConfigElement;
 import yalter.mousetweaks.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 public class ConfigGui extends GuiConfig {
-	private static Property rmbTweak = new Property("RMB tweak", "true", Property.Type.BOOLEAN);
-	private static Property lmbTweakWithItem = new Property("LMB tweak with item", "true", Property.Type.BOOLEAN);
-	private static Property lmbTweakWithoutItem = new Property("LMB tweak without item", "true",
-	                                                           Property.Type.BOOLEAN);
-	private static Property wheelTweak = new Property("Wheel tweak", "true", Property.Type.BOOLEAN);
-	private static Property wheelSearchOrder = new Property("Wheel tweak search order",
-	                                                        "Last to first",
-	                                                        Property.Type.STRING,
-	                                                        new String[]{ "First to last", "Last to first" });
-	private static Property wheelScrollDirection = new Property("Wheel tweak scroll direction",
-	                                                            Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_NORMAL,
-	                                                            Property.Type.STRING,
-	                                                            new String[]{ Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_NORMAL,
-	                                                                          Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVERTED,
-	                                                                          Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE,
-	                                                                          Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE_INVERTED });
-	private static Property onTickMethodOrder = new Property("OnTick method order",
-	                                                         "Forge, LiteLoader",
-	                                                         Property.Type.STRING);
-	private static Property scrollHandling = new Property("Scroll handling",
-	                                                      "Smooth scrolling, minor issues",
-	                                                      Property.Type.STRING,
-	                                                      new String[]{ "Smooth scrolling, minor issues",
-	                                                                    "Non-smooth scrolling, no issues" });
-	private static Property scrollItemScaling = new Property("Scroll item scaling",
-															 "Relative to scroll amount",
-															 Property.Type.STRING,
-															 new String[]{ "Relative to scroll amount",
-																		   "Always exactly one item" });
-	private static Property debug = new Property("Debug", "false", Property.Type.BOOLEAN);
-
+	private static Property rmbTweak = booleanProperty("RMB tweak", true);
+	private static Property lmbTweakWithItem = booleanProperty("LMB tweak with item", true);
+	private static Property lmbTweakWithoutItem = booleanProperty("LMB tweak without item", true);
+	private static Property wheelTweak = booleanProperty("Wheel tweak", true);
+	private static Property wheelSearchOrder = choiceProperty("Wheel tweak search order", "Last to first", "First to last");
+	private static Property wheelScrollDirection = choiceProperty(
+		"Wheel tweak scroll direction",
+		"Down to push, up to pull",
+		"Up to push, down to pull",
+		"Inventory position aware",
+		"Inventory position aware, inverted"
+	);
+	private static Property onTickMethodOrder = new Property(
+		"OnTick method order",
+		"Forge, LiteLoader",
+		Property.Type.STRING
+	);
+	private static Property scrollHandling = choiceProperty(
+		"Scroll handling",
+		"Smooth scrolling, minor issues",
+		"Non-smooth scrolling, no issues"
+	);
+	private static Property scrollItemScaling = choiceProperty(
+		"Scroll item scaling",
+		"Relative to scroll amount",
+		"Always exactly one item"
+	);
+	private static Property debug = booleanProperty("Debug", false);
+	
+	private static Property booleanProperty(String name, boolean defaultValue) {
+		return new Property(name, Boolean.toString(defaultValue), Property.Type.BOOLEAN);
+	}
+	
+	/** creates a new string property with the given valid values, taking the first valid value as default */
+	private static Property choiceProperty(String name, String... values) {
+		return new Property(name, values[0], Property.Type.STRING, values);
+	}
+	
 	private boolean is_open = false;
-
+	
 	public ConfigGui(GuiScreen parentScreen) {
 		super(parentScreen, getConfigElements(), Constants.MOD_ID, false, false, ".minecraft/config/MouseTweaks.cfg");
-
+		
 		rmbTweak.setComment(
 			"Like vanilla right click dragging, but dragging over a slot multiple times puts the item there multiple "
-			+ "times.");
+				+ "times.");
 		lmbTweakWithItem.setComment("Left click and drag with an item to \"left click\" items of the same type.");
 		lmbTweakWithoutItem.setComment("Hold shift, left click and drag without an item to \"shift left click\" items.");
 		wheelTweak.setComment("Scroll over items to move them between inventories.");
 		wheelSearchOrder.setComment("How to pick the source slot when pulling items via scrolling.");
 		wheelScrollDirection.setComment(
 			"Inventory position aware means scroll up to push items from the bottom inventory and pull into the top "
-			+ "inventory, and vice versa.");
+				+ "inventory, and vice versa.");
 		onTickMethodOrder.setComment(
 			"This shouldn't really affect anything, but non-smooth scrolling works only with the Forge OnTick method.");
 		scrollHandling.setComment(
 			"When set to smooth scrolling, minor issues may be experienced such as scrolling \"through\" "
-			+ "JEI or other mods. Non-smooth scrolling works only with the Forge OnTick method.");
+				+ "JEI or other mods. Non-smooth scrolling works only with the Forge OnTick method.");
 		scrollItemScaling.setComment("This determines how many items are moved when you scroll. On some setups (notably macOS), scrolling the wheel with different speeds results in different distances scrolled per wheel \"bump\". To make those setups play nicely with Mouse Tweaks, set this option to \"Always exactly one item\".");
 		debug.setComment("Enables debug logging output.");
 	}
-
+	
 	private static List<IConfigElement> getConfigElements() {
 		List<IConfigElement> list = new ArrayList<IConfigElement>();
-
+		
 		list.add(new ConfigElement(rmbTweak));
 		list.add(new ConfigElement(lmbTweakWithItem));
 		list.add(new ConfigElement(lmbTweakWithoutItem));
@@ -80,81 +85,58 @@ public class ConfigGui extends GuiConfig {
 		list.add(new ConfigElement(scrollHandling));
 		list.add(new ConfigElement(scrollItemScaling));
 		list.add(new ConfigElement(debug));
-
+		
 		return list;
 	}
-
+	
 	@Override
 	public void initGui() {
 		Logger.DebugLog("initGui()");
-
+		
 		if (!is_open) {
 			is_open = true;
-
+			
 			Main.config.read();
 			rmbTweak.set(Main.config.rmbTweak);
 			lmbTweakWithItem.set(Main.config.lmbTweakWithItem);
 			lmbTweakWithoutItem.set(Main.config.lmbTweakWithoutItem);
 			wheelTweak.set(Main.config.wheelTweak);
 			wheelSearchOrder.set((Main.config.wheelSearchOrder == WheelSearchOrder.FIRST_TO_LAST)
-			                     ? "First to last"
-			                     : "Last to first");
-			wheelScrollDirection.set(scrollDirectionDescription());
+				? "First to last"
+				: "Last to first");
+			wheelScrollDirection.set(wheelScrollDirection.getValidValues()[Main.config.wheelScrollDirection.ordinal()]);
 			onTickMethodOrder.set(Main.config.onTickMethodOrderString());
 			scrollHandling.set(scrollHandling.getValidValues()[Main.config.scrollHandling.ordinal()]);
 			scrollItemScaling.set(scrollItemScaling.getValidValues()[Main.config.scrollItemScaling.ordinal()]);
 			debug.set(Config.debug);
 		}
-
+		
 		super.initGui();
 	}
-
-	private String scrollDirectionDescription() {
-		WheelScrollDirection dir = Main.config.wheelScrollDirection;
-		if (dir == WheelScrollDirection.NORMAL) {
-			return Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_NORMAL;
-		} else if (dir == WheelScrollDirection.INVERTED) {
-			return Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVERTED;
-		} else {
-			return Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE;
-		}
-	}
-
+	
 	@Override
 	public void onGuiClosed() {
 		Logger.DebugLog("onGuiClosed()");
-
+		
 		Main.config.rmbTweak = rmbTweak.getBoolean();
 		Main.config.lmbTweakWithItem = lmbTweakWithItem.getBoolean();
 		Main.config.lmbTweakWithoutItem = lmbTweakWithoutItem.getBoolean();
 		Main.config.wheelTweak = wheelTweak.getBoolean();
 		Main.config.wheelSearchOrder = wheelSearchOrder.getString().equals("First to last")
-		                               ? WheelSearchOrder.FIRST_TO_LAST
-		                               : WheelSearchOrder.LAST_TO_FIRST;
-		Main.config.wheelScrollDirection = scrollDirectionFromDescription(wheelScrollDirection.getString());
+			? WheelSearchOrder.FIRST_TO_LAST
+			: WheelSearchOrder.LAST_TO_FIRST;
+		Main.config.wheelScrollDirection = WheelScrollDirection.fromId(Arrays.asList(wheelScrollDirection.getValidValues())
+			.indexOf(wheelScrollDirection.getString()));
 		Main.config.onTickMethodOrderFromString(onTickMethodOrder.getString());
 		Main.config.scrollHandling = ScrollHandling.fromId(Arrays.asList(scrollHandling.getValidValues())
-		                                                         .indexOf(scrollHandling.getString()));
+			.indexOf(scrollHandling.getString()));
 		Main.config.scrollItemScaling = ScrollItemScaling.fromId(Arrays.asList(scrollItemScaling.getValidValues())
 			.indexOf(scrollItemScaling.getString()));
 		Config.debug = debug.getBoolean();
 		Main.config.save();
 		Main.findOnTickMethod(true);
-
+		
 		is_open = false;
 		super.onGuiClosed();
-	}
-
-	private WheelScrollDirection scrollDirectionFromDescription(String description) {
-		switch (description) {
-			case Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_NORMAL:
-				return WheelScrollDirection.NORMAL;
-			case Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVERTED:
-				return WheelScrollDirection.INVERTED;
-			case Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE:
-				return WheelScrollDirection.INVENTORY_POSITION_AWARE;
-			default:
-				return WheelScrollDirection.INVENTORY_POSITION_AWARE_INVERTED;
-		}
 	}
 }

--- a/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
+++ b/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
@@ -53,21 +53,14 @@ public class ConfigGui extends GuiConfig {
 	public ConfigGui(GuiScreen parentScreen) {
 		super(parentScreen, getConfigElements(), Constants.MOD_ID, false, false, ".minecraft/config/MouseTweaks.cfg");
 		
-		rmbTweak.setComment(
-			"Like vanilla right click dragging, but dragging over a slot multiple times puts the item there multiple "
-				+ "times.");
+		rmbTweak.setComment("Like vanilla right click dragging, but dragging over a slot multiple times puts the item there multiple times.");
 		lmbTweakWithItem.setComment("Left click and drag with an item to \"left click\" items of the same type.");
 		lmbTweakWithoutItem.setComment("Hold shift, left click and drag without an item to \"shift left click\" items.");
 		wheelTweak.setComment("Scroll over items to move them between inventories.");
 		wheelSearchOrder.setComment("How to pick the source slot when pulling items via scrolling.");
-		wheelScrollDirection.setComment(
-			"Inventory position aware means scroll up to push items from the bottom inventory and pull into the top "
-				+ "inventory, and vice versa.");
-		onTickMethodOrder.setComment(
-			"This shouldn't really affect anything, but non-smooth scrolling works only with the Forge OnTick method.");
-		scrollHandling.setComment(
-			"When set to smooth scrolling, minor issues may be experienced such as scrolling \"through\" "
-				+ "JEI or other mods. Non-smooth scrolling works only with the Forge OnTick method.");
+		wheelScrollDirection.setComment("Inventory position aware means scroll up to push items from the bottom inventory and pull into the top inventory, and vice versa.");
+		onTickMethodOrder.setComment("This shouldn't really affect anything, but non-smooth scrolling works only with the Forge OnTick method.");
+		scrollHandling.setComment("When set to smooth scrolling, minor issues may be experienced such as scrolling \"through\" JEI or other mods. Non-smooth scrolling works only with the Forge OnTick method.");
 		scrollItemScaling.setComment("This determines how many items are moved when you scroll. On some setups (notably macOS), scrolling the wheel with different speeds results in different distances scrolled per wheel \"bump\". To make those setups play nicely with Mouse Tweaks, set this option to \"Always exactly one item\".");
 		debug.setComment("Enables debug logging output.");
 	}

--- a/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
+++ b/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
@@ -26,7 +26,8 @@ public class ConfigGui extends GuiConfig {
 	                                                            Property.Type.STRING,
 	                                                            new String[]{ Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_NORMAL,
 	                                                                          Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVERTED,
-	                                                                          Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE });
+	                                                                          Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE,
+	                                                                          Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE_INVERTED });
 	private static Property onTickMethodOrder = new Property("OnTick method order",
 	                                                         "Forge, LiteLoader",
 	                                                         Property.Type.STRING);
@@ -150,8 +151,10 @@ public class ConfigGui extends GuiConfig {
 				return WheelScrollDirection.NORMAL;
 			case Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVERTED:
 				return WheelScrollDirection.INVERTED;
-			default:
+			case Constants.WHELL_SCROLL_DIRECTION_DESCRIPTION_INVENTORY_POSITION_AWARE:
 				return WheelScrollDirection.INVENTORY_POSITION_AWARE;
+			default:
+				return WheelScrollDirection.INVENTORY_POSITION_AWARE_INVERTED;
 		}
 	}
 }

--- a/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
+++ b/src/main/java/yalter/mousetweaks/forge/ConfigGui.java
@@ -129,8 +129,8 @@ public class ConfigGui extends GuiConfig {
 		Main.config.lmbTweakWithoutItem = lmbTweakWithoutItem.getBoolean();
 		Main.config.wheelTweak = wheelTweak.getBoolean();
 		Main.config.wheelSearchOrder = wheelSearchOrder.getString().equals("First to last")
-									   ? WheelSearchOrder.FIRST_TO_LAST
-									   : WheelSearchOrder.LAST_TO_FIRST;
+		                               ? WheelSearchOrder.FIRST_TO_LAST
+		                               : WheelSearchOrder.LAST_TO_FIRST;
 		Main.config.wheelScrollDirection = scrollDirectionFromDescription(wheelScrollDirection.getString());
 		Main.config.onTickMethodOrderFromString(onTickMethodOrder.getString());
 		Main.config.scrollHandling = ScrollHandling.fromId(Arrays.asList(scrollHandling.getValidValues())

--- a/src/main/java/yalter/mousetweaks/forge/ForgeMouseState.java
+++ b/src/main/java/yalter/mousetweaks/forge/ForgeMouseState.java
@@ -16,7 +16,7 @@ import java.util.EnumSet;
  */
 public class ForgeMouseState implements IMouseState {
 	private final EnumSet<MouseButton> pressedButtons = EnumSet.noneOf(MouseButton.class);
-	private double scrollAmount = 0;
+	private int scrollAmount = 0;
 
 	/**
 	 * If set to true, uses the polling scrolling. Allows having the compatibility benefit of event-based handling for
@@ -88,9 +88,9 @@ public class ForgeMouseState implements IMouseState {
 			scrollAmount += Main.config.scrollItemScaling.scale(Mouse.getDWheel());
 		}
 
-		int amountToConsume = (int) scrollAmount;
-		this.scrollAmount -= amountToConsume;
-		return amountToConsume;
+		int amountConsumed = scrollAmount / ScrollItemScaling.scrollStep;
+		this.scrollAmount -= amountConsumed * ScrollItemScaling.scrollStep;
+		return amountConsumed;
 	}
 
 	@Override

--- a/src/main/java/yalter/mousetweaks/forge/ForgeMouseState.java
+++ b/src/main/java/yalter/mousetweaks/forge/ForgeMouseState.java
@@ -2,8 +2,7 @@ package yalter.mousetweaks.forge;
 
 import com.google.common.base.MoreObjects;
 import org.lwjgl.input.Mouse;
-import yalter.mousetweaks.IMouseState;
-import yalter.mousetweaks.MouseButton;
+import yalter.mousetweaks.*;
 
 import java.util.EnumSet;
 
@@ -43,7 +42,7 @@ public class ForgeMouseState implements IMouseState {
 				pressedButtons.remove(eventButton);
 			}
 		} else {
-			scrollAmount += Mouse.getEventDWheel();
+			scrollAmount += Main.config.scrollItemScaling.scale(Mouse.getEventDWheel());
 		}
 		// clear any pressed buttons in case we missed them being released
 		pressedButtons.removeIf(mouseButton -> !Mouse.isButtonDown(mouseButton.getValue()));
@@ -87,7 +86,7 @@ public class ForgeMouseState implements IMouseState {
 		this.scrollAmount = 0;
 
 		if (simpleScrolling)
-			return Mouse.getDWheel();
+			return Main.config.scrollItemScaling.scale(Mouse.getDWheel());
 		else
 			return scrollAmount;
 	}

--- a/src/main/java/yalter/mousetweaks/forge/ForgeMouseState.java
+++ b/src/main/java/yalter/mousetweaks/forge/ForgeMouseState.java
@@ -16,7 +16,7 @@ import java.util.EnumSet;
  */
 public class ForgeMouseState implements IMouseState {
 	private final EnumSet<MouseButton> pressedButtons = EnumSet.noneOf(MouseButton.class);
-	private int scrollAmount = 0;
+	private double scrollAmount = 0;
 
 	/**
 	 * If set to true, uses the polling scrolling. Allows having the compatibility benefit of event-based handling for
@@ -42,7 +42,9 @@ public class ForgeMouseState implements IMouseState {
 				pressedButtons.remove(eventButton);
 			}
 		} else {
-			scrollAmount += Main.config.scrollItemScaling.scale(Mouse.getEventDWheel());
+			if (!simpleScrolling) {
+				scrollAmount += Main.config.scrollItemScaling.scale(Mouse.getEventDWheel());
+			}
 		}
 		// clear any pressed buttons in case we missed them being released
 		pressedButtons.removeIf(mouseButton -> !Mouse.isButtonDown(mouseButton.getValue()));
@@ -82,13 +84,13 @@ public class ForgeMouseState implements IMouseState {
 	 */
 	@Override
 	public int consumeScrollAmount() {
-		int scrollAmount = this.scrollAmount;
-		this.scrollAmount = 0;
+		if (simpleScrolling) {
+			scrollAmount += Main.config.scrollItemScaling.scale(Mouse.getDWheel());
+		}
 
-		if (simpleScrolling)
-			return Main.config.scrollItemScaling.scale(Mouse.getDWheel());
-		else
-			return scrollAmount;
+		int amountToConsume = (int) scrollAmount;
+		this.scrollAmount -= amountToConsume;
+		return amountToConsume;
 	}
 
 	@Override


### PR DESCRIPTION
The current config options for scrolling behavior didn't cover my situation, so I added what I needed, as closely in line with the existing code as I could:

- A way to have it transfer exactly one item on each scroll event, rather than proportionally to the wheel delta reported. This makes it match up with the "bumps" on my mouse's scroll wheel.
- An inverted version of the position-aware scrolling. I really like the idea of the position-aware scrolling, but it's intuitively inverted for me. This makes the combinations of (static & content-aware) × (normal & inverted) complete.