### PR TITLE
Adding config for inverse push order

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ neoVersion=21.3.3-beta
 neoLoaderVersion=[4,)
 
 fabricMcVersion=1.21.3
-fabricLoaderVersion=0.16.7
+fabricLoaderVersion=0.16.8
 fabricApiVersion=0.106.1+1.21.3
 fabricModMenuVersion=12.0.0-beta.1

--- a/src/main/java/yalter/mousetweaks/Config.java
+++ b/src/main/java/yalter/mousetweaks/Config.java
@@ -15,6 +15,7 @@ public class Config {
     public WheelScrollDirection wheelScrollDirection = WheelScrollDirection.NORMAL;
     public ScrollItemScaling scrollItemScaling = ScrollItemScaling.PROPORTIONAL;
     public static boolean debug = false;
+    public boolean inversePushOrder = false;
 
     Config(String fileName) {
         this.fileName = fileName;
@@ -51,6 +52,7 @@ public class Config {
                         0));
         scrollItemScaling = ScrollItemScaling.fromId(parseIntOrDefault(properties.getProperty(Constants.CONFIG_SCROLL_ITEM_SCALING), 0));
         debug = parseIntOrDefault(properties.getProperty(Constants.CONFIG_DEBUG), 0) != 0;
+        inversePushOrder = parseIntOrDefault(properties.getProperty(Constants.CONFIG_INVERSE_PUSH_ORDER), 0) != 0;
     }
 
     private static int parseIntOrDefault(String s, int defaultValue) {
@@ -81,6 +83,7 @@ public class Config {
                     String.valueOf(wheelScrollDirection.ordinal()));
             writeString(configWriter, Constants.CONFIG_SCROLL_ITEM_SCALING, String.valueOf(scrollItemScaling.ordinal()));
             writeBoolean(configWriter, Constants.CONFIG_DEBUG, debug);
+            writeBoolean(configWriter, Constants.CONFIG_INVERSE_PUSH_ORDER, inversePushOrder);
 
             configWriter.close();
 

--- a/src/main/java/yalter/mousetweaks/ConfigScreen.java
+++ b/src/main/java/yalter/mousetweaks/ConfigScreen.java
@@ -70,6 +70,9 @@ public class ConfigScreen extends Screen {
         this.addRenderableWidget(CycleButton.onOffBuilder(Config.debug)
                 .create(this.width / 2 - 155, this.height / 6 + 24 * 5, 310, 20,
                         Component.literal("Debug Mode"), (button, value) -> Config.debug = value));
+        this.addRenderableWidget(CycleButton.onOffBuilder(Main.config.inversePushOrder)
+                .create(this.width / 2 - 155, this.height / 6 + 24 * 6, 310, 20,
+                        Component.literal("Inverse Push Order"), (cycleButton, value) -> Main.config.inversePushOrder = value));
 
         this.addRenderableWidget(Button.builder(CommonComponents.GUI_DONE, button -> this.onClose())
                 .bounds(this.width / 2 - 100, this.height - 27, 200, 20).build());

--- a/src/main/java/yalter/mousetweaks/Constants.java
+++ b/src/main/java/yalter/mousetweaks/Constants.java
@@ -11,4 +11,5 @@ public class Constants {
     static final String CONFIG_WHEEL_SCROLL_DIRECTION = "WheelScrollDirection";
     static final String CONFIG_DEBUG = "Debug";
     static final String CONFIG_SCROLL_ITEM_SCALING = "ScrollItemScaling";
+    static final String CONFIG_INVERSE_PUSH_ORDER = "InversePushOrder";
 }

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -634,8 +634,7 @@ public class Main {
              config.inversePushOrder ? i >= 0 : i < slots.size() && itemCount > 0;
              i += config.inversePushOrder ? -1 : 1) {
             Slot slot = slots.get(i);
-            System.out.println(config.inversePushOrder);
-
+            
             // Skip ignored slots.
             if (handler.isIgnored(slot))
                 continue;

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -630,8 +630,11 @@ public class Main {
         // Applicable empty slots, they can be used once applicable non-empty slots run out.
         List<Slot> goodEmptySlots = new ArrayList<>();
 
-        for (int i = 0; i != slots.size() && itemCount > 0; i++) {
+        for (int i = config.inversePushOrder ? slots.size() - 1 : 0;
+             config.inversePushOrder ? i >= 0 : i < slots.size() && itemCount > 0;
+             i += config.inversePushOrder ? -1 : 1) {
             Slot slot = slots.get(i);
+            System.out.println(config.inversePushOrder);
 
             // Skip ignored slots.
             if (handler.isIgnored(slot))


### PR DESCRIPTION
This almost definitely isn't ready for primetime, I only tested for myself on Fabric 1.21.4. I'm just uploading my quick and dirty private change to prioritise my hotbar. 

All this change does is add a config to invert the order that slots are evaluated starting from the lower right slot of an inventory to the top left, in practice for me this means that my hotbar slot 9 is prioritised over the first open slot in my inventory ( like talked about in #148 ) 