### PR TITLE
Add right click tweak support for crafter block gui

### DIFF
--- a/src/main/java/yalter/mousetweaks/IGuiScreenHandler.java
+++ b/src/main/java/yalter/mousetweaks/IGuiScreenHandler.java
@@ -20,4 +20,6 @@ public interface IGuiScreenHandler {
     boolean isCraftingOutput(Slot slot);
 
     boolean isIgnored(Slot slot);
+
+    boolean isCrafterToggleableSlot(Slot slot);
 }

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -31,6 +31,10 @@ public class Main {
     private static boolean canDoLMBDrag = false;
     private static boolean canDoRMBDrag = false;
     private static boolean rmbTweakLeftOriginalSlot = false;
+    
+    // Variables for Crafter block right-click dragging support
+    private static boolean isRMBDraggingInCrafter = false;
+    private static java.util.Set<Integer> toggledCrafterSlotIndices = new java.util.HashSet<>();
 
     private static boolean initialized = false;
 
@@ -62,6 +66,8 @@ public class Main {
         canDoLMBDrag = false;
         canDoRMBDrag = false;
         rmbTweakLeftOriginalSlot = false;
+        isRMBDraggingInCrafter = false;
+        toggledCrafterSlotIndices.clear();
 
         if (openScreen != null) {
             Logger.DebugLog("You have just opened a " + openScreen.getClass().getName() + ".");
@@ -115,6 +121,21 @@ public class Main {
             if (stackOnMouse.isEmpty())
                 canDoLMBDrag = true;
         } else if (button == MouseButton.RIGHT) {
+            // Special handling for Crafter blocks - allow right click dragging with empty hand
+            if (oldSelectedSlot != null && handler.isCrafterToggleableSlot(oldSelectedSlot)) {
+                // For Crafter containers, we want to enable right-click dragging to toggle slot states
+                isRMBDraggingInCrafter = true;
+                canDoRMBDrag = true;
+                // Clear the set of toggled slot indices for a new drag operation
+                toggledCrafterSlotIndices.clear();
+                // Add the initial slot to our tracked slots and toggle it
+                toggledCrafterSlotIndices.add(oldSelectedSlot.index);
+                // Click the slot to toggle its state
+                handler.clickSlot(oldSelectedSlot, MouseButton.RIGHT, false);
+                return true;  // Handle the event to prevent vanilla behavior
+            }
+            
+            // Standard behavior for non-Crafter containers
             // We're only interested in the RMB tweak when there's something on the mouse.
             if (stackOnMouse.isEmpty())
                 return false;
@@ -187,8 +208,16 @@ public class Main {
         // Reset the flags.
         if (button == MouseButton.LEFT)
             canDoLMBDrag = false;
-        else if (button == MouseButton.RIGHT)
+        else if (button == MouseButton.RIGHT) {
             canDoRMBDrag = false;
+            
+            // Also reset Crafter-specific state
+            if (isRMBDraggingInCrafter) {
+                isRMBDraggingInCrafter = false;
+                toggledCrafterSlotIndices.clear();
+                return true; // Handle the event
+            }
+        }
 
         return false;
     }
@@ -287,7 +316,21 @@ public class Main {
         } else if (button == MouseButton.RIGHT) {
             if (!canDoRMBDrag)
                 return false;
+                
+            // Special handling for Crafter blocks
+            if (handler instanceof GuiContainerHandler && isRMBDraggingInCrafter && selectedSlot != null && handler.isCrafterToggleableSlot(selectedSlot)) {
+                // If we haven't already toggled this slot in the current drag operation
+                if (!toggledCrafterSlotIndices.contains(selectedSlot.index)) {
+                    // Add to our toggled slots set to prevent toggling the same slot multiple times
+                    toggledCrafterSlotIndices.add(selectedSlot.index);
+                    // Click the slot to toggle its state
+                    handler.clickSlot(selectedSlot, MouseButton.RIGHT, false);
+                    return true;  // We handled the event
+                }
+                return false;
+            }
 
+            // Standard behavior for non-Crafter containers
             rmbTweakMaybeClickSlot(selectedSlot, stackOnMouse);
         }
 

--- a/src/main/java/yalter/mousetweaks/handlers/GuiContainerHandler.java
+++ b/src/main/java/yalter/mousetweaks/handlers/GuiContainerHandler.java
@@ -2,6 +2,7 @@ package yalter.mousetweaks.handlers;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.inventory.CrafterScreen;
 import net.minecraft.world.inventory.*;
 import yalter.mousetweaks.IGuiScreenHandler;
 import yalter.mousetweaks.MouseButton;
@@ -74,5 +75,13 @@ public class GuiContainerHandler implements IGuiScreenHandler {
     @Override
     public boolean isIgnored(Slot slot) {
         return false;
+    }
+    
+    @Override
+    public boolean isCrafterToggleableSlot(Slot slot) {
+        // Check if this is a Crafter screen and the slot can be toggled
+        return screen instanceof CrafterScreen && 
+               !isCraftingOutput(slot) && 
+               !isIgnored(slot);
     }
 }

--- a/src/main/java/yalter/mousetweaks/handlers/IMTModGuiContainer3ExHandler.java
+++ b/src/main/java/yalter/mousetweaks/handlers/IMTModGuiContainer3ExHandler.java
@@ -2,6 +2,7 @@ package yalter.mousetweaks.handlers;
 
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.client.gui.screens.inventory.CrafterScreen;
 import yalter.mousetweaks.IGuiScreenHandler;
 import yalter.mousetweaks.MouseButton;
 import yalter.mousetweaks.api.IMTModGuiContainer3Ex;
@@ -55,5 +56,14 @@ public class IMTModGuiContainer3ExHandler implements IGuiScreenHandler {
     @Override
     public boolean isIgnored(Slot slot) {
         return modGuiContainer.MT_isIgnored(slot);
+    }
+    
+    @Override
+    public boolean isCrafterToggleableSlot(Slot slot) {
+        // Delegate to the API implementation if available, otherwise use standard detection
+        if (modGuiContainer instanceof CrafterScreen) {
+            return !isCraftingOutput(slot) && !isIgnored(slot);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Description
Adds right-click tweak support to the crafter block GUI. This reduces the need for excessive right-clicking when using a crafter as subtraction component in comparator setups, as well as for recipes that require only a small number of items and therefore need most slots to be disabled.

## Changes
- Improved mouse interaction handling for the crafter block GUI
- Added right-click functionality to streamline inventory management
- Updated GUI handlers to correctly process right-click events in crafter blocks

## Testing
Tested the right-click functionality in the crafter block GUI on Fabric; works flawlessly.

## Notes
If you have a preferred or specific way to implement this (different from my current approach), feel free to let me know and I’ll be happy to adapt it. I tried to follow and comply with the existing codebase as much as possible.